### PR TITLE
Fixes __transfer_sensory_memory() not being passed the results

### DIFF
--- a/haystack_memory/utils.py
+++ b/haystack_memory/utils.py
@@ -82,7 +82,7 @@ class RedisUtils:
             self.redis.expire(self.memory_id, self.expiration)
             self.__expiration_is_set = True
         self.redis.rpush(self.memory_id, result["query"])
-        self.__transfer_sensory_memory()
+        self.__transfer_sensory_memory(result)
         self.redis.rpush(self.memory_id, result["answers"][0].answer)
 
     def chat(self,


### PR DESCRIPTION
Fixes __transfer_sensory_memory() not being passed the results, and therefore crashing out the whole node.